### PR TITLE
Add selected country state

### DIFF
--- a/src/components/MapChart.tsx
+++ b/src/components/MapChart.tsx
@@ -6,7 +6,14 @@ import type { FeatureCollection } from 'geojson';
 import * as htmlToImage from 'html-to-image';
 import { saveAs } from 'file-saver';
 
-export default function MapChart() {
+export interface MapChartProps {
+  /**
+   * Called when the user selects a country on the map.
+   */
+  onSelect?: (country: string) => void;
+}
+
+export default function MapChart({ onSelect }: MapChartProps) {
   /* state & refs */
   const [geo, setGeo] = useState<FeatureCollection | null>(null);
   const [pop, setPop] = useState<Record<string, number>>({});
@@ -87,6 +94,7 @@ export default function MapChart() {
       mouseout:  () => layer.setStyle({ weight: 0.5, color: 'rgba(255,255,255,0.5)' })
     });
     layer.on('click', () => {
+      if (onSelect) onSelect(name);
       if (!mapRef.current) return;
       const bounds = (layer as any).getBounds() as L.LatLngBounds;
       const pad: L.PointTuple = [40, 40];

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -1,10 +1,22 @@
 import MapChart from '../components/MapChart';
+import { useState } from 'react';
 
 export default function MapPage() {
+  const [selectedCountries, setSelectedCountries] = useState<string[]>([]);
+
+  const handleSelect = (country: string) => {
+    setSelectedCountries(prev => {
+      if (prev.includes(country)) return prev;
+      if (prev.length >= 2) return [prev[1], country];
+      return [...prev, country];
+    });
+  };
+
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-4">Map Page</h1>
-      <MapChart />
+      <MapChart onSelect={handleSelect} />
+      <div className="mt-4 text-sm">Selected: {selectedCountries.join(', ') || 'none'}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow MapChart to signal when a country is clicked
- track up to two selected countries in MapPage
- display the selected country names below the map

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862e6094780832d958eb4e0a20c0a22