### PR TITLE
Add selected country state

### DIFF
--- a/src/components/DataCard.tsx
+++ b/src/components/DataCard.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { csv } from 'd3-fetch';
+import { scaleLinear } from 'd3-scale';
+
+export interface DataCardProps {
+  countries: string[];
+}
+
+interface Row { country: string; value: number; }
+
+export default function DataCard({ countries }: DataCardProps) {
+  const [data, setData] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    csv('/latam_population_2023.csv', d => ({ country: d.country as string, value: +d.value! }))
+      .then(rows => {
+        const lookup: Record<string, number> = {};
+        rows.forEach(r => (lookup[r.country] = r.value));
+        setData(lookup);
+      });
+  }, []);
+
+  const values = countries.map(c => data[c]).filter(v => v != null);
+  const maxVal = values.length ? Math.max(...values) : 0;
+  const x = scaleLinear().domain([0, maxVal || 1]).range([0, 150]);
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 w-full md:w-80">
+      <h2 className="text-lg font-semibold mb-4">Population</h2>
+      {countries.length === 0 ? (
+        <p className="text-sm text-gray-600">Select a country</p>
+      ) : (
+        <svg width={200} height={countries.length * 28} className="overflow-visible">
+          {countries.map((name, i) => {
+            const val = data[name];
+            if (val == null) return null;
+            const barW = x(val);
+            return (
+              <g key={name} transform={`translate(0, ${i * 24})`}>
+                <text x={0} y={14} className="text-xs">{name}</text>
+                <rect x={70} y={4} width={barW} height={16} fill="#3B82F6" rx={2} />
+                <text x={70 + barW + 4} y={16} className="text-xs">{val.toLocaleString()}</text>
+              </g>
+            );
+          })}
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/src/components/MapChart.tsx
+++ b/src/components/MapChart.tsx
@@ -6,7 +6,14 @@ import type { FeatureCollection } from 'geojson';
 import * as htmlToImage from 'html-to-image';
 import { saveAs } from 'file-saver';
 
-export default function MapChart() {
+export interface MapChartProps {
+  /**
+   * Called when the user selects a country on the map.
+   */
+  onSelect?: (country: string) => void;
+}
+
+export default function MapChart({ onSelect }: MapChartProps) {
   /* state & refs */
   const [geo, setGeo] = useState<FeatureCollection | null>(null);
   const [pop, setPop] = useState<Record<string, number>>({});
@@ -87,6 +94,7 @@ export default function MapChart() {
       mouseout:  () => layer.setStyle({ weight: 0.5, color: 'rgba(255,255,255,0.5)' })
     });
     layer.on('click', () => {
+      if (onSelect) onSelect(name);
       if (!mapRef.current) return;
       const bounds = (layer as any).getBounds() as L.LatLngBounds;
       const pad: L.PointTuple = [40, 40];

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -1,10 +1,25 @@
 import MapChart from '../components/MapChart';
+import DataCard from '../components/DataCard';
+import { useState } from 'react';
 
 export default function MapPage() {
+  const [selectedCountries, setSelectedCountries] = useState<string[]>([]);
+
+  const handleSelect = (country: string) => {
+    setSelectedCountries(prev => {
+      if (prev.includes(country)) return prev;
+      if (prev.length >= 2) return [prev[1], country];
+      return [...prev, country];
+    });
+  };
+
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-4">Map Page</h1>
-      <MapChart />
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+        <MapChart onSelect={handleSelect} />
+        <DataCard countries={selectedCountries} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow MapChart to signal when a country is clicked
- track up to two selected countries in MapPage
- display a new DataCard comparing the selected countries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862e6094780832d958eb4e0a20c0a22