### PR TITLE
Remove duplicate map view

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -14,14 +14,13 @@ export default function MapPage() {
   };
 
   return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold mb-4">Map Page</h1>
-      <div className="flex flex-col lg:flex-row gap-6 items-start">
-        <MapChart onSelect={handleSelect} />
-        <DataCard countries={selectedCountries} />
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">Map Page</h1>
+        <div className="flex flex-col lg:flex-row gap-6 items-start">
+          <MapChart onSelect={handleSelect} />
+          <DataCard countries={selectedCountries} />
+        </div>
+        <div className="mt-4 text-sm">Selected: {selectedCountries.join(', ') || 'none'}</div>
       </div>
-      <MapChart onSelect={handleSelect} />
-      <div className="mt-4 text-sm">Selected: {selectedCountries.join(', ') || 'none'}</div>
-    </div>
-  );
+    );
 }


### PR DESCRIPTION
## Summary
- remove extra `MapChart` component from Map page so that only one map card is shown

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862f00d05bc832d90095398668100f7